### PR TITLE
Fix broken javascript on pre-ES5 browsers (IE).

### DIFF
--- a/web-notification.html
+++ b/web-notification.html
@@ -223,7 +223,7 @@ Example:
         return null;
       },
       
-      closeNotification (key) {
+      closeNotification: function (key) {
         if (this._notifications[key] && typeof this._notifications[key].close === 'function') {
           this._notifications[key].close();
         }
@@ -233,18 +233,18 @@ Example:
         delete this._notifications[key];
       },
       
-      _autoAskPermission(){
+      _autoAskPermission: function () {
         if (!this.autoAskPermission) {
           return;
         }
         this.askForPermission();
       },
             
-      _onWindowFocus(){
+      _onWindowFocus: function () {
         this.windowFocus = true;
       },
 
-      _onWindowBlur(){
+      _onWindowBlur: function () {
         this.windowFocus = false;
       },
 


### PR DESCRIPTION
A random assortment of `function` and no-`function`'s on the object, fixed to be the proper syntax and follow the style of the surrounding code.

Fixed IE11, potentially older ones as well. They do not have notifications but having a web-notification element on a site in IE11 should at least allow the rest of the page to work. :-)